### PR TITLE
Test before using SIGUNUSED

### DIFF
--- a/src/cgroup.cc
+++ b/src/cgroup.cc
@@ -1065,7 +1065,9 @@ static string clone_flags_to_str(int clone_flags) {
     TEST_FLAG(SIGIO);
     TEST_FLAG(SIGPWR);
     TEST_FLAG(SIGSYS);
+#ifdef SIGUNUSED
     TEST_FLAG(SIGUNUSED);
+#endif
 #undef TEST_FLAG
     if (v) {
         s += strconv::from_long((long)v);


### PR DESCRIPTION
According to [man7.org](http://man7.org/linux/man-pages/man7/signal.7.html):
>        Where defined, SIGUNUSED is synonymous with SIGSYS on most
>       architectures.  Since glibc 2.26, SIGUNUSED is no longer defined on
>       any architecture.

as well as [gnu.org](https://lists.gnu.org/archive/html/info-gnu/2017-08/msg00000.html):
>* The obsolete signal constant SIGUNUSED is no longer defined by <signal.h>.

`SIGUNUSED` has been removed in newer version of glibc. Therefore, using it without checking might result in compilation errors.

This pull request added a simple `#ifdef` check before using `SIGUNUSED` in `clone_flags_to_str`.